### PR TITLE
add chunkhash to generate js bundle name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ function createRewire(params) {
       }, {});
 
       // checkme: possibly is not required in production env
-      config.output.filename = 'static/js/[name].bundle.js';
+      config.output.filename = 'static/js/[name].[chunkhash:8].js';
 
       // initial HtmlWebpackPlugin for `index.html`
       config.plugins = replacePlugin(config.plugins, (name) => /HtmlWebpackPlugin/i.test(name), getHtmlPlugin(bundles[0], isProd));

--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,7 @@ function createRewire(params) {
         return acc;
       }, {});
 
-      // checkme: possibly is not required in production env
-      config.output.filename = 'static/js/[name].[chunkhash:8].js';
+      config.output.filename = isProd ? 'static/js/[name].[chunkhash:8].js' : 'static/js/[name].bundle.js';
 
       // initial HtmlWebpackPlugin for `index.html`
       config.plugins = replacePlugin(config.plugins, (name) => /HtmlWebpackPlugin/i.test(name), getHtmlPlugin(bundles[0], isProd));


### PR DESCRIPTION
Hi, a quick PR to keep CRA's behaviour and use a bundle hash in the name. This makes it easier to deploy and get clients to not use a cached previous version when you update the app.

see https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpack.config.prod.js#L122 and https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpack.config.dev.js#L111